### PR TITLE
Fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.2",
   "description": "gulp plugin for dart2js",
   "main": "index.js",
-  "repository": "revathskumar/gulp-dart2js",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/revathskumar/gulp-dart2js.git"
+  }
   "author": {
     "name": "Revath S Kumar",
     "email": "rsk@revathskumar.com",


### PR DESCRIPTION
Please use [valid package.json descriptions](https://npmjs.org/doc/json.html#repository). NPM _requires_ the repo field on package.json to be a JSON object with properties 'type' and 'url'. 
