### PR TITLE
ability to set a different than '.js' extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = function (out, options) {
       return cb(null, file);
     }
 
-    var filename = gutil.replaceExtension(file.path, '.js')
+    var fileExtension = options.fileExtension || '.js'
+    var filename = gutil.replaceExtension(file.path, fileExtension)
     filename = filename.split('/');
     var destPath = process.cwd() + '/' +  out;
     var dest = destPath + filename[filename.length -1] ;


### PR DESCRIPTION
Hello,

I've added ability to set a different than '.js' extension.
It's useful when dart files connected with dart.js script:

``` html
<script type="application/dart" src="main.dart"></script>
<script src="packages/browser/dart.js"></script>
```

If browser supports dart files it will use main.dart otherwise it will download main.dart.js
